### PR TITLE
Force amd64 pgdg repository

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -5,7 +5,7 @@
   when: postgresql_flavor is defined and postgresql_flavor == "pgdg"
   
 - name: Install pgdg repository (Debian/pgdg)
-  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main" update_cache=yes
+  apt_repository: repo="deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main" update_cache=yes
   when: postgresql_flavor is defined and postgresql_flavor == "pgdg"
 
 - name: Install PostgreSQL (Debian)


### PR DESCRIPTION
This fixes the problem with missing pgdg i386 architecture APT repository in Ubuntu 20 and later.

Focal
http://apt.postgresql.org/pub/repos/apt/dists/focal-pgdg/10/